### PR TITLE
New join with higher limits - 64

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,7 @@
             "type": "lldb",
             "request": "launch",
             "name": "Debug",
-            "program": "${workspaceFolder}/build/cars",
+            "program": "${workspaceFolder}/build/persona",
             "args": [],
             "preLaunchTask": "build",
             "cwd": "${workspaceFolder}/build"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,7 @@
             "type": "lldb",
             "request": "launch",
             "name": "Debug",
-            "program": "${workspaceFolder}/build/noLiteDb",
+            "program": "${workspaceFolder}/build/cars",
             "args": [],
             "preLaunchTask": "build",
             "cwd": "${workspaceFolder}/build"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,9 @@ option(NLDB_SHOW_ID_WARNING "Prints a warning if the requested is not the intern
 # ------------------ CONFIGURATION DEV ----------------- #
 option(NLDB_DEBUG_CACHE_BUFFER "Shows cache hit/miss and buffer warnings" OFF)
 
-option(NLDB_DEBUG_QUERY "Displays executed queries and human-readable aliases")
+option(NLDB_DEBUG_QUERY "Displays executed queries and human-readable aliases" OFF)
+
+option(NLDB_PROFILE "Profile query execution time." OFF)
 
 # ----------------------- SOURCES ---------------------- #
 file(GLOB_RECURSE SOURCES src/*.cpp)
@@ -49,6 +51,7 @@ foreach(_VAR IN ITEMS
     NLDB_DEBUG_QUERY
     NLDB_DEBUG_CACHE_BUFFER
     NLDB_SHOW_ID_WARNING
+    NLDB_PROFILE
 )
     if(${_VAR})
         target_compile_definitions(noLitedb_lb PUBLIC "${_VAR}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ option(NLDB_SHOW_ID_WARNING "Prints a warning if the requested is not the intern
 # ------------------ CONFIGURATION DEV ----------------- #
 option(NLDB_DEBUG_CACHE_BUFFER "Shows cache hit/miss and buffer warnings" OFF)
 
+option(NLDB_DEBUG_QUERY "Displays executed queries and human-readable aliases")
 
 # ----------------------- SOURCES ---------------------- #
 file(GLOB_RECURSE SOURCES src/*.cpp)
@@ -42,11 +43,22 @@ add_library(noLitedb_lb ${SOURCES})
 
 add_dependencies(noLitedb_lb ${DEPENDENCY_LIST})
 target_include_directories(noLitedb_lb PUBLIC ${DEPENDENCY_INCLUDE_DIR} ${DEPENDENCY_INCLUDE_LIST})
+
+# boolean definitions
+foreach(_VAR IN ITEMS
+    NLDB_DEBUG_QUERY
+    NLDB_DEBUG_CACHE_BUFFER
+    NLDB_SHOW_ID_WARNING
+)
+    if(${_VAR})
+        target_compile_definitions(noLitedb_lb PUBLIC "${_VAR}")
+    endif()
+endforeach()
+
+# valued definitions
 target_compile_definitions(noLitedb_lb 
     PUBLIC 
     "NLDB_INTERNAL_ID=\"${NLDB_INTERNAL_ID}\"" 
-    NLDB_SHOW_ID_WARNING=${NLDB_SHOW_ID_WARNING}
-    NLDB_DEBUG_CACHE_BUFFER=${NLDB_DEBUG_CACHE_BUFFER}
 )
 
 target_link_libraries(noLitedb_lb PUBLIC ${DEPENDENCY_LIBS})

--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ This is an embedded `c++` document oriented data base with all the CRUD operatio
     - Update by id; add new properties or update existing
     - Delete by id
 
-# Example
+# Examples
+check out all the examples in [here](/examples)
+
 ```c++
 #include "nlohmann/json.hpp"
 #include "dbwrapper/sq3wrapper/DB.hpp"
@@ -26,50 +28,106 @@ using namespace nlohmann;
 int main() {
     DBSL3 db;
 
-    if (!db.open("./tests.db")) {
+    if (!db.open("./cars.db" /*":memory:"*/)) {
         std::cerr << "Could not open the database \n";
         db.throwLastError();
     }
 
-    // create a query object with the `db` connection and the cars collection
-    auto query = QueryFactory::create(&db, "cars");
+    // a query object can be used to execute multiple queries.
+    Query query = Query(&db);
 
-    json cars = {{{"maker", "ford"}, {"model", "focus"}, {"year", 2011}},
-                 {{"maker", "ford"}, {"model", "focus"}, {"year", 2015}},
-                 {{"maker", "subaru"}, {"model", "impreza"}, {"year", 2003}}};
+    // {name, founded, country}
+    json data_automaker = {{{"name", "ford"},
+                            {"founded", "June 16, 1903"},
+                            {"country", "United States"}},
+                           // -------------
+                           {{"name", "subaru"},
+                            {"founded", "July 15, 1953"},
+                            {"country", "Japan"}}};
 
-    const int totalChanges = query.insert(cars);
+    // {maker, model, year}
+    json data_cars = {
+        {{"maker", "ford"}, {"model", "focus"}, {"year", 2011}},
+        {{"maker", "ford"}, {"model", "focus"}, {"year", 2015}},
+        {{"maker", "subaru"}, {"model", "impreza"}, {"year", 2003}}};
 
-    auto [id, model, maker, year] =
-        query.prepareProperties("id", "model", "maker", "year");
+    // insert automakers
+    query.from("automaker").insert(data_automaker);
 
-    // get the first 10 newest model with its id, model name and maker name
-    json newestPerModel =
-        query.select(id, model, maker, year.maxAs("year_newest_model"))
-            .where(year > 1990)
-            .page(1, 10)
-            .groupBy(model, maker)
-            .execute();
+    // group all the automaker properties into the `automaker` variable.
+    Collection automakers = query.collection("automaker");
+    auto automaker = automakers.group("_id", "name", "founded", "country");
 
-    std::cout << "newest per model: " << newestPerModel << std::endl;
+    // we can obtain the properties from a collection before inserting any value
+    // in it
+    Collection cars = query.collection("cars");
+    auto [id, model, maker, year] = cars.get("_id", "model", "maker", "year");
 
-    // update first car, set year to 2418 and add a new property called price
-    query.update(res1[0]["id"], {{"year", 2418}, {"price", 50000}});
+    // insert cars data
+    query.from("cars").insert(data_cars);
 
-    // remove element with id 1
-    int totalChangesDel = query.remove(1);
+    // select all the cars with manufacturer details
+    json all = query.from("cars")
+                   .select(id, model, maker, year, automaker)
+                   .where(year > 1990 && automaker["name"] == maker)
+                   .page(1, 10)
+                   .execute();
 
-    // select all cars with all the fields
-    auto finalCars = query.select().execute();
+    std::cout << "\n\nCars with automaker: " << all.dump(2) << std::endl
+              << std::endl;
 
-    std::cout << "cars after operations: " << finalCars << std::endl;    
+    // Output:
+    // [
+    //   {
+    //       "_id": 3495450966444999936,
+    //       "automaker": {
+    //          "_id": 3495450965218165120,
+    //          "country": "United States",
+    //          "founded": "June 16, 1903",
+    //          "name": "ford"
+    //       },
+    //       "maker": "ford",
+    //       "model": "focus",
+    //       "year": 2011
+    //   },
+    //   {
+    //       "_id": 3495450966447097600,
+    //       "automaker": {
+    //          "_id": 3495450965218165120,
+    //          "country": "United States",
+    //          "founded": "June 16, 1903",
+    //          "name": "ford"
+    //       },
+    //       "maker": "ford",
+    //       "model": "focus",
+    //       "year": 2015
+    //   },
+    //   {
+    //       "_id": 3495450966447097728,
+    //       "automaker": {
+    //          "_id": 3495450965220262784,
+    //          "country": "Japan",
+    //          "founded": "July 15, 1953",
+    //          "name": "subaru"
+    //       },
+    //       "maker": "subaru",
+    //       "model": "impreza",
+    //       "year": 2003
+    //   }
+    // ]
 }
 ```
 
-## Limits
+# Limits
 - Up to 64 properties/members/name value pair per object
     
     This limit comes from the [sqlite maximum number of tables in a join](https://www.sqlite.org/limits.html#:~:text=Maximum%20Number%20Of%20Tables%20In%20A%20Join) and since we do a new select subquery for each object.
 
+# Identifiers
+- Ids are 64 bits long integers with the
+    - first 43 bits to store the timestamp in milliseconds
+    - 7 bits for the thread/process id
+    - 14 bits thread element counter
+
 ## *Note*
-You can read more about this project in my [~~devlog~~ 🚧]()
+You can read more about this project, the process of generating identifiers, performance tests and the inner workings  of it in my [~~devlog~~ 🚧]()

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 This is an embedded `c++` document oriented data base with all the CRUD operations and with support for most common queries. Its main DTO (data transfer object) is [nlohmann::json](https://github.com/nlohmann/json).
 
 # Features
+- Multi platforms
 - Built-in SQLite3 backend support
 - Full C++ API, no need to write any SQL string
 - CRUD operations
@@ -11,6 +12,7 @@ This is an embedded `c++` document oriented data base with all the CRUD operatio
         - sort by properties
         - pagination
         - group by properties
+        - join multiple collections
     - Update by id; add new properties or update existing
     - Delete by id
 
@@ -60,16 +62,14 @@ int main() {
     // select all cars with all the fields
     auto finalCars = query.select().execute();
 
-    std::cout << "cars after operations: " finalCars << std::endl;    
+    std::cout << "cars after operations: " << finalCars << std::endl;    
 }
 ```
 
+## Limits
+- Up to 64 properties/members/name value pair per object
+    
+    This limit comes from the [sqlite maximum number of tables in a join](https://www.sqlite.org/limits.html#:~:text=Maximum%20Number%20Of%20Tables%20In%20A%20Join) and since we do a new select subquery for each object.
+
 ## *Note*
 You can read more about this project in my [~~devlog~~ 🚧]()
-
-It was intended to serve as a fast development tool for a backend server where I needed an embedded NoSQL database that just worked with json objects out of the box.
-
-# Next
-Since this version (1.0) was just to explore how to make it work, it has some problems. For example **working across different databases and collections can fail** due to the way in which we cache the properties. 
-
-So in version 2.0, I expect to solve all the pending problems and actually think about the design. Also, it might work with the SOCI library. All of this without changing the query API, so it's an internal reowork.

--- a/examples/persona.cpp
+++ b/examples/persona.cpp
@@ -28,6 +28,7 @@ int main() {
 
     DBSL3 db;
 
+    // remove("./tests.db");
     if (!db.open("./tests.db" /*":memory:"*/)) {
         std::cerr << "Could not open the database \n";
         db.throwLastError();
@@ -78,8 +79,8 @@ int main() {
     now = std::chrono::high_resolution_clock::now();
     auto result = collQuery.from("persona")
                       .select()
-                      .where(_id != 9)
-                      .sortBy(contact["email"].desc())
+                      //   .where(_id != 9)
+                      //   .sortBy(contact["email"].desc())
                       .execute();
 
     std::cout << "select took "

--- a/examples/twitter.cpp
+++ b/examples/twitter.cpp
@@ -47,12 +47,9 @@ int main() {
               << " ms" << std::endl;
 
     now = std::chrono::high_resolution_clock::now();
-    // Select all won't work because this dataset has more than 64 properties,
-    // which is the maximum join limit of sqlite. If you really want to handle
-    // data of this size then you can use something like firebird that enables
-    // up to 256 joins.
-    // https://www.ibphoenix.com/resources/documents/general/doc_323#:~:text=Maximum%20number%20of%20joined%20tables,evaluations%20required%20by%20the%20joins.
-    auto res = query.from("tweets").select().page(1, 1000).execute();
+
+    // Select all does work (Y)
+    auto res = query.from("tweets").select().page(1, 100).execute();
 
     std::cout << res << std::endl;
 

--- a/examples/twitter.cpp
+++ b/examples/twitter.cpp
@@ -46,6 +46,7 @@ int main() {
                      std::chrono::milliseconds(1)
               << " ms" << std::endl;
 
+    now = std::chrono::high_resolution_clock::now();
     // Select all won't work because this dataset has more than 64 properties,
     // which is the maximum join limit of sqlite. If you really want to handle
     // data of this size then you can use something like firebird that enables
@@ -54,6 +55,11 @@ int main() {
     auto res = query.from("tweets").select().page(1, 10).execute();
 
     std::cout << res << std::endl;
+
+    std::cout << "select took "
+              << (std::chrono::high_resolution_clock::now() - now) /
+                     std::chrono::milliseconds(1)
+              << " ms" << std::endl;
 
     nldb::LogManager::Shutdown();
 }

--- a/examples/twitter.cpp
+++ b/examples/twitter.cpp
@@ -52,9 +52,11 @@ int main() {
     // data of this size then you can use something like firebird that enables
     // up to 256 joins.
     // https://www.ibphoenix.com/resources/documents/general/doc_323#:~:text=Maximum%20number%20of%20joined%20tables,evaluations%20required%20by%20the%20joins.
-    auto res = query.from("tweets").select().page(1, 10).execute();
+    auto res = query.from("tweets").select().page(1, 1000).execute();
 
     std::cout << res << std::endl;
+
+    std::cout << "size: " << res.size() << std::endl;
 
     std::cout << "select took "
               << (std::chrono::high_resolution_clock::now() - now) /

--- a/src/DAL/BufferData.cpp
+++ b/src/DAL/BufferData.cpp
@@ -25,8 +25,6 @@ namespace nldb {
         NLDB_PERF_SUCCESS("FLUSHING PENDING DATA");
         lock.lock();  // next push should wait
 
-        auto now = std::chrono::high_resolution_clock::now();
-
         if (bufferRootProperty.Size() > 0) {
             this->pushRootProperties();
         }
@@ -50,11 +48,6 @@ namespace nldb {
         if (bufferStringLike.Size() > 0) {
             this->pushStringLikeValues();
         }
-
-        NLDB_PERF_SUCCESS("buffer insert took {} ms",
-                          (std::chrono::high_resolution_clock::now() - now) /
-                              std::chrono::milliseconds(1),
-                          " ms");
 
         lock.unlock();
     }

--- a/src/Property/Property.cpp
+++ b/src/Property/Property.cpp
@@ -1,6 +1,7 @@
 #include "nldb/Property/Property.hpp"
 
 #include "nldb/Common.hpp"
+#include "nldb/LOG/log.hpp"
 #include "nldb/Property/AggregatedProperty.hpp"
 #include "nldb/Property/PropertyExpression.hpp"
 #include "nldb/Property/SortedProperty.hpp"
@@ -16,7 +17,7 @@ namespace nldb {
         if (pName == common::internal_id_string) {
             type = PropertyType::ID;
         }
-#if NLDB_SHOW_ID_WARNING
+#ifdef NLDB_SHOW_ID_WARNING
         if (pName != common::internal_id_string && pName == "id") {
             NLDB_WARN(
                 "If you are trying to get the document id, use the "

--- a/src/Query/QueryRunner.cpp
+++ b/src/Query/QueryRunner.cpp
@@ -118,7 +118,9 @@ namespace nldb {
 
         if (data.documents.is_array()) {
             for (auto& doc : data.documents) {
+#ifdef NLDB_DEBUG_QUERY
                 NLDB_TRACE("INSERTING {}", doc.dump(2));
+#endif
                 insertDocumentRecursive(doc, from.getName());
             }
         } else {

--- a/src/Query/QueryRunner.cpp
+++ b/src/Query/QueryRunner.cpp
@@ -14,6 +14,7 @@
 #include "nldb/DAL/Repositories.hpp"
 #include "nldb/Exceptions.hpp"
 #include "nldb/LOG/log.hpp"
+#include "nldb/Profiling/Profiler.hpp"
 #include "nldb/Property/Property.hpp"
 #include "nldb/Property/SortedProperty.hpp"
 #include "nldb/Query/QueryContext.hpp"
@@ -85,49 +86,67 @@ namespace nldb {
     }
 
     void QueryRunner::update(QueryPlannerContextUpdate&& data) {
-        populateData(data);
+        NLDB_PROFILE_BEGIN_SESSION("update", "nldb-profile-update.json");
 
-        // check if doc exists
-        snowflake& docID = data.documentID;
-        if (!repos->valuesDAO->existsObject(docID)) {
-            throw DocumentNotFound("id: " + std::to_string(docID));
+        {
+            NLDB_PROFILE_FUNCTION();
+            populateData(data);
+
+            // check if doc exists
+            snowflake& docID = data.documentID;
+            if (!repos->valuesDAO->existsObject(docID)) {
+                throw DocumentNotFound("id: " + std::to_string(docID));
+            }
+
+            // get the collection
+            auto& from = *data.from.begin();
+
+            updateDocumentRecursive(docID, from, data.object);
+
+            repos->buffered->pushPendingData();
         }
 
-        // get the collection
-        auto& from = *data.from.begin();
-
-        updateDocumentRecursive(docID, from, data.object);
-
-        repos->buffered->pushPendingData();
+        NLDB_PROFILE_END_SESSION();
     }
 
     void QueryRunner::insert(QueryPlannerContextInsert&& data) {
-        NLDB_ASSERT(data.from.size() > 0, "missing target collection");
+        NLDB_PROFILE_BEGIN_SESSION("insert", "nldb-profile-insert.json");
 
-        if (data.from.size() > 1) {
-            NLDB_WARN("multiple collections given in an insert clause");
-        }
+        {
+            NLDB_PROFILE_FUNCTION();
 
-        try {
-            populateData(data);
-        } catch (CollectionNotFound& e) {
-            // expected, do nothing
-        }
+            NLDB_ASSERT(data.from.size() > 0, "missing target collection");
 
-        Collection& from = *data.from.begin();
-
-        if (data.documents.is_array()) {
-            for (auto& doc : data.documents) {
-#ifdef NLDB_DEBUG_QUERY
-                NLDB_TRACE("INSERTING {}", doc.dump(2));
-#endif
-                insertDocumentRecursive(doc, from.getName());
+            if (data.from.size() > 1) {
+                NLDB_WARN("multiple collections given in an insert clause");
             }
-        } else {
-            insertDocumentRecursive(data.documents, from.getName());
+
+            try {
+                populateData(data);
+            } catch (CollectionNotFound& e) {
+                // expected, do nothing
+            }
+
+            Collection& from = *data.from.begin();
+
+            if (data.documents.is_array()) {
+                for (auto& doc : data.documents) {
+#ifdef NLDB_DEBUG_QUERY
+                    NLDB_TRACE("INSERTING {}", doc.dump(2));
+#endif
+                    insertDocumentRecursive(doc, from.getName());
+                }
+            } else {
+                insertDocumentRecursive(data.documents, from.getName());
+            }
+
+            {
+                NLDB_PROFILE_SCOPE("Flush data");
+                repos->buffered->pushPendingData();
+            }
         }
 
-        repos->buffered->pushPendingData();
+        NLDB_PROFILE_END_SESSION();
     }
 
     void QueryRunner::remove(QueryPlannerContextRemove&& data) {
@@ -172,6 +191,8 @@ namespace nldb {
          * "contact" property to that function, so it knows the parent
          * prop.
          */
+
+        NLDB_PROFILE_FUNCTION();
 
         //  - Add the collection if missing
         auto [collID, rootPropID] =
@@ -225,6 +246,7 @@ namespace nldb {
     void QueryRunner::updateDocumentRecursive(snowflake objID,
                                               const Collection& collection,
                                               json& object) {
+        NLDB_PROFILE_FUNCTION();
         for (auto& [propName, valueJson] : object.items()) {
             std::optional<Property> found =
                 repos->repositoryProperty->find(collection.getId(), propName);
@@ -393,6 +415,8 @@ namespace nldb {
     }
 
     void QueryRunner::populateData(QueryPlannerContextSelect& data) {
+        NLDB_PROFILE_FUNCTION();
+
         populateData((QueryPlannerContext&)data);
         auto cb = overloaded {
             [this](auto& prop) { populateData(prop); },

--- a/src/backends/sqlite3/DAL/BufferDataSQ3.cpp
+++ b/src/backends/sqlite3/DAL/BufferDataSQ3.cpp
@@ -5,6 +5,7 @@
 
 #include "backends/sqlite3/DAL/Definitions.hpp"
 #include "nldb/LOG/log.hpp"
+#include "nldb/Profiling/Profiler.hpp"
 #include "nldb/Property/Property.hpp"
 #include "nldb/Utils/ParamsBindHelpers.hpp"
 
@@ -14,6 +15,8 @@ namespace nldb {
     BufferDataSQ3::BufferDataSQ3(IDB* db) : BufferData(db) {}
 
     void BufferDataSQ3::pushRootProperties() {
+        NLDB_PROFILE_FUNCTION();
+
         std::stringstream root_prop_sql;
         root_prop_sql << "insert into property (id, name, type) values ";
 
@@ -33,6 +36,8 @@ namespace nldb {
     }
 
     void BufferDataSQ3::pushCollections() {
+        NLDB_PROFILE_FUNCTION();
+
         std::stringstream coll_sql;
         coll_sql << "insert into collection (id, name, owner_id) values ";
 
@@ -51,6 +56,8 @@ namespace nldb {
     }
 
     void BufferDataSQ3::pushProperties() {
+        NLDB_PROFILE_FUNCTION();
+
         std::stringstream prop_sql;
         prop_sql << "insert into property (id, name, type, coll_id) values ";
 
@@ -70,6 +77,8 @@ namespace nldb {
     }
 
     void BufferDataSQ3::pushIndependentObjects() {
+        NLDB_PROFILE_FUNCTION();
+
         auto& tables = tables::getPropertyTypesTable();
 
         // first insert the objects that does not depend on other
@@ -97,6 +106,8 @@ namespace nldb {
     }
 
     void BufferDataSQ3::pushDependentObjects() {
+        NLDB_PROFILE_FUNCTION();
+
         auto& tables = tables::getPropertyTypesTable();
 
         // now that we have inserted the object that does not depend on other
@@ -126,6 +137,8 @@ namespace nldb {
     }
 
     void BufferDataSQ3::pushStringLikeValues() {
+        NLDB_PROFILE_FUNCTION();
+
         auto& tables = tables::getPropertyTypesTable();
 
         std::map<PropertyType, std::stringstream> queries;

--- a/src/backends/sqlite3/DB/DB.cpp
+++ b/src/backends/sqlite3/DB/DB.cpp
@@ -55,7 +55,9 @@ namespace nldb {
 
     std::unique_ptr<IDBQueryReader> DBSL3::executeReader(
         const std::string& query, const Paramsbind& params) {
-        // NLDB_TRACE("Executing: {}", query.c_str());
+#ifdef NLDB_DEBUG_QUERY
+        NLDB_TRACE("Executing: {}", query.c_str());
+#endif
 
         if (query.empty()) {
             NLDB_ERROR("Empty query");
@@ -125,9 +127,9 @@ namespace nldb {
          * sqlite3_exec.
          */
         std::string sql = utils::paramsbind::parseSQL(query, params);
-
-        // NLDB_TRACE("Executing: {}", sql);
-
+#ifdef NLDB_DEBUG_QUERY
+        NLDB_TRACE("Executing: {}", sql);
+#endif
         char* err = 0;
         int rc = sqlite3_exec(db, sql.c_str(), 0, 0, &err);
 

--- a/src/backends/sqlite3/Query/QueryRunnerCtx.hpp
+++ b/src/backends/sqlite3/Query/QueryRunnerCtx.hpp
@@ -6,6 +6,7 @@
 #include "nldb/DB/IDB.hpp"
 #include "nldb/Object.hpp"
 #include "nldb/Query/QueryRunner.hpp"
+#include "nldb/typedef.hpp"
 
 namespace nldb {
 
@@ -28,12 +29,27 @@ namespace nldb {
 
         std::string_view getAlias(const AggregatedProperty& agProp);
 
-        std::string getValueExpression(const Property& prop);
+        /**
+         * @brief Get the property alias. It depends on the context.
+         *
+         * let isPassThrough = statementCollId == prop.getCollID()
+         * If `isPassThrough` is true, then we already have its value and
+         * therefore returns {prop.name}_{id}, otherwise it returns a statement
+         * to get its value.
+         *
+         * @param prop
+         * @param statementCollId if the current statement collection id
+         * @return std::string
+         */
+        std::string getContextualizedAlias(const Property& prop,
+                                           snowflake statementCollId);
 
         void set(Object& composed);
 
         snowflake getRootCollId();
         snowflake getRootPropId();
+
+        std::string getValueExpression(const Property& prop);
 
        private:
         // {prop_id, prop_coll_id} -> alias

--- a/src/include/nldb/LOG/log.hpp
+++ b/src/include/nldb/LOG/log.hpp
@@ -27,7 +27,7 @@
         NLDB_BREAK                                                          \
     }
 
-#if NLDB_DEBUG_CACHE_BUFFER
+#ifdef NLDB_DEBUG_CACHE_BUFFER
 #define NLDB_PERF_SUCCESS(...) NLDB_INFO(__VA_ARGS__)
 #define NLDB_PERF_FAIL(...) NLDB_WARN(__VA_ARGS__)
 #else

--- a/src/include/nldb/Profiling/Profiler.hpp
+++ b/src/include/nldb/Profiling/Profiler.hpp
@@ -1,0 +1,235 @@
+#pragma once
+
+// to use with https://ui.perfetto.dev/ or the legacy chrome://tracing/
+// from https://gist.github.com/enzo418/e0d3ab1b3cd7e0dcd92de4b51db39c51
+
+#include <algorithm>
+#include <chrono>
+#include <fstream>
+#include <iomanip>
+#include <mutex>
+#include <sstream>
+#include <string>
+#include <thread>
+
+#include "nldb/LOG/log.hpp"
+
+namespace nldb {
+
+    using FloatingPointMicroseconds = std::chrono::duration<double, std::micro>;
+
+    struct ProfileResult {
+        std::string Name;
+
+        FloatingPointMicroseconds Start;
+        std::chrono::microseconds ElapsedTime;
+        std::thread::id ThreadID;
+    };
+
+    struct InstrumentationSession {
+        std::string Name;
+    };
+
+    class Instrumentor {
+       public:
+        Instrumentor(const Instrumentor&) = delete;
+        Instrumentor(Instrumentor&&) = delete;
+
+        void BeginSession(const std::string& name,
+                          const std::string& filepath = "results.json") {
+            std::lock_guard lock(m_Mutex);
+            if (m_CurrentSession) {
+                if (LogManager::GetLogger()) {
+                    NLDB_ERROR(
+                        "Instrumentor::BeginSession('{0}') when session '{1}' "
+                        "already open.",
+                        name, m_CurrentSession->Name);
+                }
+                InternalEndSession();
+            }
+            m_OutputStream.open(filepath);
+
+            if (m_OutputStream.is_open()) {
+                m_CurrentSession = new InstrumentationSession({name});
+                WriteHeader();
+            } else if (LogManager::GetLogger()) {
+                NLDB_ERROR("Instrumentor could not open results file '{0}'.",
+                           filepath);
+            }
+        }
+
+        void EndSession() {
+            std::lock_guard lock(m_Mutex);
+            InternalEndSession();
+        }
+
+        void WriteProfile(const ProfileResult& result) {
+            std::lock_guard lock(m_Mutex);
+            m_Results.push_back(result);
+        }
+
+        static Instrumentor& Get() {
+            static Instrumentor instance;
+            return instance;
+        }
+
+       private:
+        Instrumentor() : m_CurrentSession(nullptr) {}
+
+        ~Instrumentor() { EndSession(); }
+
+        void WriteHeader() {
+            m_OutputStream << "{\"otherData\": {},\"traceEvents\":[{}";
+            m_OutputStream.flush();
+        }
+
+        void WriteFooter() {
+            m_OutputStream << "]}";
+            m_OutputStream.flush();
+        }
+
+        void InternalEndSession() {
+            if (m_CurrentSession) {
+                for (auto& result : m_Results) {
+                    m_OutputStream << std::setprecision(3) << std::fixed;
+                    m_OutputStream << ",{";
+                    m_OutputStream << "\"cat\":\"function\",";
+                    m_OutputStream << "\"dur\":" << (result.ElapsedTime.count())
+                                   << ',';
+                    m_OutputStream << "\"name\":\"" << result.Name << "\",";
+                    m_OutputStream << "\"ph\":\"X\",";
+                    m_OutputStream << "\"pid\":0,";
+                    m_OutputStream << "\"tid\":" << result.ThreadID << ",";
+                    m_OutputStream << "\"ts\":" << result.Start.count();
+                    m_OutputStream << "}";
+                }
+
+                WriteFooter();
+                m_OutputStream.close();
+                delete m_CurrentSession;
+                m_CurrentSession = nullptr;
+                m_Results.clear();
+            }
+        }
+
+       private:
+        std::mutex m_Mutex;
+        InstrumentationSession* m_CurrentSession;
+        std::ofstream m_OutputStream;
+        std::vector<ProfileResult> m_Results;
+    };
+
+    class InstrumentationTimer {
+       public:
+        InstrumentationTimer(const char* name)
+            : m_Name(name), m_Stopped(false) {
+            m_StartTimepoint = std::chrono::steady_clock::now();
+        }
+
+        ~InstrumentationTimer() {
+            if (!m_Stopped) Stop();
+        }
+
+        void Stop() {
+            auto endTimepoint = std::chrono::steady_clock::now();
+            auto highResStart =
+                FloatingPointMicroseconds {m_StartTimepoint.time_since_epoch()};
+            auto elapsedTime =
+                std::chrono::time_point_cast<std::chrono::microseconds>(
+                    endTimepoint)
+                    .time_since_epoch() -
+                std::chrono::time_point_cast<std::chrono::microseconds>(
+                    m_StartTimepoint)
+                    .time_since_epoch();
+
+            Instrumentor::Get().WriteProfile({m_Name, highResStart, elapsedTime,
+                                              std::this_thread::get_id()});
+
+            m_Stopped = true;
+        }
+
+       private:
+        const char* m_Name;
+        std::chrono::time_point<std::chrono::steady_clock> m_StartTimepoint;
+        bool m_Stopped;
+    };
+
+    namespace InstrumentorUtils {
+
+        template <size_t N>
+        struct ChangeResult {
+            char Data[N];
+        };
+
+        template <size_t N, size_t K>
+        constexpr auto CleanupOutputString(const char (&expr)[N],
+                                           const char (&remove)[K]) {
+            ChangeResult<N> result = {};
+
+            size_t srcIndex = 0;
+            size_t dstIndex = 0;
+            while (srcIndex < N) {
+                size_t matchIndex = 0;
+                while (matchIndex < K - 1 && srcIndex + matchIndex < N - 1 &&
+                       expr[srcIndex + matchIndex] == remove[matchIndex])
+                    matchIndex++;
+                if (matchIndex == K - 1) srcIndex += matchIndex;
+                result.Data[dstIndex++] =
+                    expr[srcIndex] == '"' ? '\'' : expr[srcIndex];
+                srcIndex++;
+            }
+            return result;
+        }
+    }  // namespace InstrumentorUtils
+}  // namespace nldb
+
+#if NLDB_PROFILE
+   // Resolve which function signature macro will be used. Note that this only
+// is resolved when the (pre)compiler starts, so the syntax highlighting
+// could mark the wrong one in your editor!
+#if defined(__GNUC__) || (defined(__MWERKS__) && (__MWERKS__ >= 0x3000)) || \
+    (defined(__ICC) && (__ICC >= 600)) || defined(__ghs__)
+#define NLDB_FUNC_SIG __PRETTY_FUNCTION__
+#elif defined(__DMC__) && (__DMC__ >= 0x810)
+#define NLDB_FUNC_SIG __PRETTY_FUNCTION__
+#elif (defined(__FUNCSIG__) || (_MSC_VER))
+#define NLDB_FUNC_SIG __FUNCSIG__
+#elif (defined(__INTEL_COMPILER) && (__INTEL_COMPILER >= 600)) || \
+    (defined(__IBMCPP__) && (__IBMCPP__ >= 500))
+#define NLDB_FUNC_SIG __FUNCTION__
+#elif defined(__BORLANDC__) && (__BORLANDC__ >= 0x550)
+#define NLDB_FUNC_SIG __FUNC__
+#elif defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901)
+#define NLDB_FUNC_SIG __func__
+#elif defined(__cplusplus) && (__cplusplus >= 201103)
+#define NLDB_FUNC_SIG __func__
+#else
+#define NLDB_FUNC_SIG "NLDB_FUNC_SIG unknown!"
+#endif
+
+#define NLDB_PROFILE_BEGIN_SESSION(name, filepath) \
+    ::nldb::Instrumentor::Get().BeginSession(name, filepath)
+#define NLDB_PROFILE_END_SESSION() ::nldb::Instrumentor::Get().EndSession()
+#define NLDB_PROFILE_SCOPE_LINE2(name, line)                              \
+    constexpr auto fixedName##line =                                      \
+        ::nldb::InstrumentorUtils::CleanupOutputString(name, "__cdecl "); \
+    ::nldb::InstrumentationTimer timer##line(fixedName##line.Data)
+#define NLDB_PROFILE_SCOPE_LINE(name, line) NLDB_PROFILE_SCOPE_LINE2(name, line)
+#define NLDB_PROFILE_SCOPE(name) NLDB_PROFILE_SCOPE_LINE(name, __LINE__)
+#define NLDB_PROFILE_FUNCTION() NLDB_PROFILE_SCOPE(NLDB_FUNC_SIG)
+#define NLDB_PROFILE_CALL__(name, line, ...)                              \
+    constexpr auto fixedName##line =                                      \
+        ::nldb::InstrumentorUtils::CleanupOutputString(name, "__cdecl "); \
+    ::nldb::InstrumentationTimer timer##line(fixedName##line.Data);       \
+    __VA_ARGS__;                                                          \
+    timer##line.Stop();
+#define NLDB_PROFILE_CALL(name, ...) \
+    NLDB_PROFILE_CALL__(name, __LINE__, __VA_ARGS__);
+
+#else
+#define NLDB_PROFILE_BEGIN_SESSION(name, filepath)
+#define NLDB_PROFILE_END_SESSION()
+#define NLDB_PROFILE_SCOPE(name)
+#define NLDB_PROFILE_FUNCTION()
+#define NLDB_PROFILE_CALL(...) __VA_ARGS__
+#endif


### PR DESCRIPTION
- New query builder that removes the previous restriction of up to 64 members in the query scope. Now the limit is 64 but for each object.
- Profiling macros
- fixed bug while reading query with multiple sub-objects